### PR TITLE
 compose.yaml: No need to expose 11434 externally in prod

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,6 @@
 services:
   ollama:
     image: "docker.io/ollama/ollama"
-    ports:
-      - "11434:11434"
     volumes:
       - ollama-storage:/root/.ollama
     entrypoint: ["/usr/bin/bash", "-c", "/bin/ollama serve & sleep 5; ollama pull ${OLLAMA_MODEL}; wait"]


### PR DESCRIPTION
Inter-container communication works fine without exposing the ports externally.

Related https://github.com/oasisprotocol/demo-rofl-chatbot/pull/27