### PR TITLE
Use TELEGRAM_API_TOKEN env name and keep TOKEN as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ A simple Telegram bot running inside Oasis ROFL TEE deployed on the
 
 ```shell
 pip install -r requirements.txt
-TOKEN="0123456789:your_telegram_token" python bot.py
+TELEGRAM_API_TOKEN="0123456789:your_telegram_token" python bot.py
 ```
 
 ## Run inside docker
 
 ```shell
-TOKEN="0123456789:your_telegram_token" docker compose up
+TELEGRAM_API_TOKEN="0123456789:your_telegram_token" docker compose up
 ```
 
 ## Run as a ROFL app
@@ -31,7 +31,7 @@ rm rofl.yaml
 oasis rofl init
 oasis rofl create
 oasis build
-echo -n "0123456789:your_telegram_token" | oasis rofl secret set TOKEN -
+echo -n "0123456789:your_telegram_token" | oasis rofl secret set TELEGRAM_API_TOKEN -
 oasis rofl update
 oasis rofl deploy
 ```

--- a/bot.py
+++ b/bot.py
@@ -6,9 +6,9 @@ async def hello(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(f'Hello {update.effective_user.first_name}')
 
 
-app = ApplicationBuilder().token(os.getenv("TOKEN")).build()
+token = os.getenv("TELEGRAM_API_TOKEN") or os.getenv("TOKEN")
+app = ApplicationBuilder().token(token).build()
 
 app.add_handler(CommandHandler("hello", hello))
 
 app.run_polling()
-

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,5 +4,5 @@ services:
     image: "ghcr.io/oasisprotocol/demo-rofl-tgbot@sha256:2d5e9010d1d4cbe41254567487d0ab26152abb4eeaa94169c8ec57dd053b19fb"
     platform: linux/amd64
     environment:
+      - TELEGRAM_API_TOKEN=${TELEGRAM_API_TOKEN}
       - TOKEN=${TOKEN}
-

--- a/rofl.yaml
+++ b/rofl.yaml
@@ -38,5 +38,5 @@ deployments:
       fees: endorsing_node
       max_expiration: 3
     secrets:
-      - name: TOKEN
+      - name: TELEGRAM_API_TOKEN
         value: pGJwa1ggNxLBy/2sBXhh8ShwiqC5CQdTpI8b1yhG5JKN09JWGl9kbmFtZVU5a6ofrB25gdjLEbiu+v4VSR4JYjFlbm9uY2VPb3EfKc24DIbIWDTmbvQfZXZhbHVlWD6xALlgZkK++PEok01Ou6p+XQY9aNPdDCilDYG705PgAUe+lWsB7DCN3nj0Abc5JG+vC+fwG7h4zDd4Rc3Q6g==


### PR DESCRIPTION
Init work to resolve `rename the Telegram API token variable from TOKEN to TELEGRAM_API_TOKEN` https://github.com/oasisprotocol/rofl-app/issues/231 

